### PR TITLE
Rename class method encrypt() to encrypt_tokens().

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -119,7 +119,7 @@ module Sorcery
       end
 
       # encrypt tokens using current encryption_provider.
-      def encrypt(*tokens)
+      def encrypt_tokens(*tokens)
         return tokens.first if @sorcery_config.encryption_provider.nil?
 
         set_encryption_attributes
@@ -185,7 +185,7 @@ module Sorcery
       def encrypt_password
         config = sorcery_config
         send(:"#{config.salt_attribute_name}=", new_salt = TemporaryToken.generate_random_token) unless config.salt_attribute_name.nil?
-        send(:"#{config.crypted_password_attribute_name}=", self.class.encrypt(send(config.password_attribute_name), new_salt))
+        send(:"#{config.crypted_password_attribute_name}=", self.class.encrypt_tokens(send(config.password_attribute_name), new_salt))
       end
 
       def clear_virtual_password

--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -173,7 +173,7 @@ shared_examples_for 'rails_3_core_model' do
       end
     end
 
-    specify { expect(User).to respond_to(:encrypt) }
+    specify { expect(User).to respond_to(:encrypt_tokens) }
 
     it 'subclass inherits config if defined so' do
       sorcery_reload!([], subclasses_inherit_config: true)
@@ -412,11 +412,11 @@ shared_examples_for 'rails_3_core_model' do
       sorcery_model_property_set(:encryption_algorithm, :aes256)
       sorcery_model_property_set(:encryption_key, nil)
 
-      expect { User.encrypt @text }.to raise_error(ArgumentError)
+      expect { User.encrypt_tokens @text }.to raise_error(ArgumentError)
 
       sorcery_model_property_set(:encryption_key, 'asd234dfs423fddsmndsflktsdf32343')
 
-      expect { User.encrypt @text }.not_to raise_error
+      expect { User.encrypt_tokens @text }.not_to raise_error
     end
 
     it 'if encryption algo is aes256, it sets key to crypto provider, even if attributes are set in reverse' do
@@ -425,31 +425,31 @@ shared_examples_for 'rails_3_core_model' do
       sorcery_model_property_set(:encryption_key, 'asd234dfs423fddsmndsflktsdf32343')
       sorcery_model_property_set(:encryption_algorithm, :aes256)
 
-      expect { User.encrypt @text }.not_to raise_error
+      expect { User.encrypt_tokens @text }.not_to raise_error
     end
 
     it 'if encryption algo is md5 it works' do
       sorcery_model_property_set(:encryption_algorithm, :md5)
 
-      expect(User.encrypt(@text)).to eq Sorcery::CryptoProviders::MD5.encrypt(@text)
+      expect(User.encrypt_tokens(@text)).to eq Sorcery::CryptoProviders::MD5.encrypt(@text)
     end
 
     it 'if encryption algo is sha1 it works' do
       sorcery_model_property_set(:encryption_algorithm, :sha1)
 
-      expect(User.encrypt(@text)).to eq Sorcery::CryptoProviders::SHA1.encrypt(@text)
+      expect(User.encrypt_tokens(@text)).to eq Sorcery::CryptoProviders::SHA1.encrypt(@text)
     end
 
     it 'if encryption algo is sha256 it works' do
       sorcery_model_property_set(:encryption_algorithm, :sha256)
 
-      expect(User.encrypt(@text)).to eq Sorcery::CryptoProviders::SHA256.encrypt(@text)
+      expect(User.encrypt_tokens(@text)).to eq Sorcery::CryptoProviders::SHA256.encrypt(@text)
     end
 
     it 'if encryption algo is sha512 it works' do
       sorcery_model_property_set(:encryption_algorithm, :sha512)
 
-      expect(User.encrypt(@text)).to eq Sorcery::CryptoProviders::SHA512.encrypt(@text)
+      expect(User.encrypt_tokens(@text)).to eq Sorcery::CryptoProviders::SHA512.encrypt(@text)
     end
 
     it 'salt is random for each user and saved in db' do


### PR DESCRIPTION
This avoids a conflict with attr_encrypted, making both gems work
in the same model.